### PR TITLE
In-Level Egg Editing

### DIFF
--- a/menu/debug_control_types.asm
+++ b/menu/debug_control_types.asm
@@ -330,9 +330,7 @@ clean_egg_inv_mirror:
 ;================================
 ; Read inventory and translate sprite ID to 
 ; proper index for debug egg inv
-;
-; TODO: Always use current egg inventory
-;       If we're inside a level
+
 egg_inv_to_debug_mirror:
   REP #$30
   LDA !egg_inv_size

--- a/menu/debug_controls.asm
+++ b/menu/debug_controls.asm
@@ -37,14 +37,7 @@ init_controls:
   JSR (debug_control_inits,x)
 
   PLY
-  DEY
-  DEY
-  DEY
-  DEY
-  DEY
-  DEY
-  DEY
-  DEY
+  DEY #8
   BPL .loop
 
   PLD

--- a/menu/debug_menu.asm
+++ b/menu/debug_menu.asm
@@ -35,14 +35,13 @@ dw $0000, $05E0, $0000, $001F
 !menu_tilemap_size = #$0700
 
 
-; hate having to use longs, but I don't understand mirroring/bank registers well enough
-!warps_page_depth_index = $0000DF   ; current page depth --  0: main menu,   1: world select,   2: level select,   3: room warp select
+!warps_page_depth_index = $00DF   ; current page depth --  0: main menu,   1: world select,   2: level select,   3: room warp select
 
-!warps_current_world_index = $0000E1
-!warps_current_level_index = $0000E3
-!warps_current_world_level_index = $0000E5
+!warps_current_world_index = $00E1
+!warps_current_level_index = $00E3
+!warps_current_world_level_index = $00E5
 
-!debug_controls_count_current = $0000E7
+!debug_controls_count_current = $00E7
 !debug_controls_count = #$0011
 
 ; handle initialization of debug menu
@@ -205,7 +204,7 @@ init_debug_menu:
     JSL vram_dma_01
 
     ; set the page index and the controls count for the main page
-    LDA #$0000 : STA !warps_page_depth_index
+    STZ !warps_page_depth_index
     LDA !debug_controls_count : STA !debug_controls_count_current
 
    ; initialize tilemap with blanktiles

--- a/region_check.asm
+++ b/region_check.asm
@@ -32,6 +32,12 @@ if read1($00FFD9) == $00
 
     world_map_new_fold_in = $17CEC5
 
+    save_eggs_to_wram = $01C4E9
+    
+    load_eggs_from_wram = $01C508
+
+    despawn_sprite_free_slot = $03A32E ; X: sprite slot
+
     vram_dma_01 = $00BC47
 
 elseif read1($00FFD9) == $01
@@ -56,6 +62,12 @@ elseif read1($00FFD9) == $01
     world_map_prev_fold_away = $17CD76
 
     world_map_new_fold_in = $17CEFB
+
+    save_eggs_to_wram = $01B2B7
+
+    load_eggs_from_wram = $01B2D6
+
+    despawn_sprite_free_slot = $03A32E ; X: sprite slot
 
     vram_dma_01 = $00BEA6
 

--- a/routines/warp_menu.asm
+++ b/routines/warp_menu.asm
@@ -324,7 +324,7 @@ macro mul(operand_a, operand_b)
   STA !reg_wrmpyb
   NOP #3
   REP #$30
-  LDA !reg_rdmpyl ; !reg_rdmpyh is high byte of product - BUG? p sure this uses bank A1 since the register is 2bytes
+  LDA !reg_rdmpyl
 
   PLP
 endmacro
@@ -489,14 +489,7 @@ load_room:
   LDA #$0001
 .load
   STA $7E038C ; Flag to enter 0: start of level, 1: different room within level
-  LDA #$000B : STA $7E0118 ; Game-mode - see https://github.com/brunovalads/yoshisisland-disassembly/wiki/Game-Modes
-  
-  ; reset music otherwise old music will continue playing when warping to a room
-  SEP #$20
-  JSR toggle_music_set_music
-  REP #$20
-
-  JSR save_egg_inventory ; just use the method from boss room warp
+  LDA #$000B : STA !gamemode ; Game-mode - see https://github.com/brunovalads/yoshisisland-disassembly/wiki/Game-Modes
   LDA !debug_menu
   BEQ .ret
   JSR exit_debug_menu

--- a/variables/game_vars.asm
+++ b/variables/game_vars.asm
@@ -7,7 +7,7 @@
 !screen_exit_level = $7F7E00
 !screen_exit_xpos = $7F7E01
 !screen_exit_ypos = $7F7E02
-!screen_exit_type = $7F7E02
+!screen_exit_type = $7F7E03
 !current_screen = $038E
 
 ; Controller data
@@ -37,6 +37,10 @@
 !item_mem_page1 = $0440
 !item_mem_page2 = $04C0
 !item_mem_page3 = $0540
+
+; Level Select
+!world_num = $0218 ; world index * 2 (0000 = world 1, 0002 = world 2, etc.)
+!level_num = $021A ; seems to store level index with the formula world*12+level, so 1-1 would be 0, 2-2 would be 13, 4-5 would be 40 ($28)
 
 ;Egg Inventory
 handle_egg_inv_routine = $01B2B7
@@ -89,6 +93,9 @@ handle_egg_inv_routine = $01B2B7
 
 !yoshi_x_speed = $60B4
 !yoshi_y_speed = $60AA
+
+; Yoshi Colour Palette
+!yoshi_colour = $0383
 
 ; SFX (see https://github.com/brunovalads/yoshisisland-disassembly/wiki/Sound-IDs)
 !sound_immediate = $0053


### PR DESCRIPTION
Updates the egg editor feature of the debug menu to track correctly while a level is loaded, and when using the warps menu.

The editor is synced to the WRAM portion of the game's egg inventory, which stores eggs in-between levels on the world map, or during room transitions, so it only worked during those states.
This PR causes the SRAM inventory to be stored into WRAM when the debug menu opens (if in-level), and loads SRAM from WRAM when closing the debug menu, basically treating it like a room transition.

Also includes a commit to load the correct Yoshi colour when using the warps menu.